### PR TITLE
wire up click events

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -23,4 +23,16 @@ export default class ApplicationController extends Controller {
 
     basemapLayersToHide.forEach(layer => map.removeLayer(layer));
   }
+
+  @action
+  handleLayerClick(feature) {
+    if (feature) {
+      const { paws_id } = feature.properties;
+      if (paws_id) {
+        this.transitionToRoute('profiles.show', paws_id);
+      } else {
+        this.transitionToRoute('index');
+      }
+    }
+  }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -30,7 +30,10 @@
       mapLoaded=(action 'handleMapLoad')
       as |map|
     }}
-      {{map.labs-layers layerGroups=model.layerGroups}}
+      {{map.labs-layers
+        layerGroups=model.layerGroups
+        onLayerClick=(action 'handleLayerClick')
+      }}
     {{/labs-map}}
   </div>
 


### PR DESCRIPTION
This PR creates events for layer clicks. WPAA sites that have paws_id open their profile route. Publicly owned sites redirect to index.