### PR TITLE
add data citations to data tab

### DIFF
--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -1,4 +1,8 @@
 import Route from '@ember/routing/route';
 
 export default Route.extend({
+  model() {
+    const sources = this.store.peekAll('source');
+    return sources.toArray().uniqBy('meta.description');
+  },
 });

--- a/app/templates/data.hbs
+++ b/app/templates/data.hbs
@@ -3,12 +3,27 @@
 </div>
 
 <div class="content cell large-5 large-order-3">
-  <h2>Data</h2>
+  <h2>Data Sources</h2>
 
-  <p>The GIS shapefiles used to create this interactive map can be downloaded here. To download the GIS shapefiles and the Publicly Accessible Waterfront Spaces (PAWS) database please go to <a href="https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-waterfront.page" target="_blank">BYTES of the BIG APPLE / NYC Publicly Accessible Waterfront</a> <span class="red">(To be updated)</span>. There, you will also find detailed information about these datasets provided in the accompanying documentation.</p>
-
-  {{!-- TODO --}}
-  <p>[pull in data sources programmatically]</p>
+    <ul>
+    {{#each model as |layerGroup|}}
+      <li>
+        <p>
+          {{#if layerGroup.meta.description}}
+            <span style="display:block;" class="dark-gray"><strong>{{layerGroup.meta.description}}</strong></span>
+          {{/if}}
+          {{#if layerGroup.meta.url}}
+            {{#each layerGroup.meta.url as |url|}}
+              <span style="display:block;" class="no-margin"><a href="{{url}}" target="_blank">{{fa-icon 'external-link-alt'}} {{url}}</a></span>
+            {{/each}}
+          {{/if}}
+          {{#if layerGroup.meta.updated_at}}
+            <span style="display:block;" class="dark-gray text-small">Updated in Waterfront Access Map: {{layerGroup.meta.updated_at}}</span>
+          {{/if}}
+        </p>
+      </li>
+    {{/each}}
+    </ul>
 
 </div>
 


### PR DESCRIPTION
- Pulled data citations from labs-layers-api meta to display on the "data" tab

- I also made some changes in labs-layers-api (added URLs and descriptions) - these are in develop but are not live yet on the staging site so they won't show up on the waterfront app until they are deployed
