### PR TITLE
Boat Launches

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -140,6 +140,11 @@ export default class ApplicationController extends Controller {
         this.transitionToRoute('index');
       }
 
+      /*if (feature.layer.id === 'boat-launches') {
+        const launchInfo = '{link}';
+        window.open(launchInfo, '_blank');
+      }*/
+
       if (feature.layer.id === 'wpaas-entry-points') {
         const [lng, lat] = feature.geometry.coordinates;
         const zoom = this.get('mapInstance').getZoom() + 2; // add 2 because google uses smaller tiles

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -140,10 +140,10 @@ export default class ApplicationController extends Controller {
         this.transitionToRoute('index');
       }
 
-      /*if (feature.layer.id === 'boat-launches') {
-        const launchInfo = '{link}';
+      if (feature.layer.id === 'boat-launches') {
+        const launchInfo = feature.properties.link;
         window.open(launchInfo, '_blank');
-      }*/
+      }
 
       if (feature.layer.id === 'wpaas-entry-points') {
         const [lng, lat] = feature.geometry.coordinates;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -22,10 +22,6 @@ export default class ApplicationRoute extends Route {
             tooltipTemplate: '<div class="gray">(click for directions)</div>',
           }],
         },
-        { id: 'bike-routes', visible: false },
-        { id: 'subway', visible: false },
-        { id: 'aerials', visible: false },
-        { id: 'ferries', visible: false },
         {
           id: 'boat-launches',
           visible: true,
@@ -33,6 +29,10 @@ export default class ApplicationRoute extends Route {
             tooltipTemplate: '{{name}}<div class="gray">(click for launch info)</div',
           }],
         },
+        { id: 'bike-routes', visible: false },
+        { id: 'subway', visible: false },
+        { id: 'aerials', visible: false },
+        { id: 'ferries', visible: false },
       ],
     });
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,6 +26,13 @@ export default class ApplicationRoute extends Route {
         { id: 'subway', visible: false },
         { id: 'aerials', visible: false },
         { id: 'ferries', visible: false },
+        {
+          id: 'boat-launches',
+          visible: true,
+          layers: [{
+            tooltipTemplate: '{{{name}}}<div class="gray">(click for more info)</div>',
+          }],
+        },
       ],
     });
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,13 +26,7 @@ export default class ApplicationRoute extends Route {
         { id: 'subway', visible: false },
         { id: 'aerials', visible: false },
         { id: 'ferries', visible: false },
-        {
-          id: 'boat-launches',
-          visible: true,
-          layers: [{
-            tooltipTemplate: '{{{name}}}<div class="gray">(click for more info)</div>',
-          }],
-        },
+        { id: 'boat-launches', visible: false },
       ],
     });
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -19,7 +19,7 @@ export default class ApplicationRoute extends Route {
           id: 'waterfront-access--entry-points',
           visible: true,
           layers: [{
-            tooltipTemplate: '<div class="gray">(click for directions)</div>',
+            tooltipTemplate: '<div class="gray">click for directions</div>',
           }],
         },
         {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -19,14 +19,20 @@ export default class ApplicationRoute extends Route {
           id: 'waterfront-access--entry-points',
           visible: true,
           layers: [{
-            tooltipTemplate: '{{{notes}}}<div class="gray">(click for directions)</div>',
+            tooltipTemplate: '<div class="gray">(click for directions)</div>',
           }],
         },
         { id: 'bike-routes', visible: false },
         { id: 'subway', visible: false },
         { id: 'aerials', visible: false },
         { id: 'ferries', visible: false },
-        { id: 'boat-launches', visible: false },
+        {
+          id: 'boat-launches',
+          visible: true,
+          layers: [{
+            tooltipTemplate: '{{name}}<div class="gray">(click for launch info)</div',
+          }],
+        },
       ],
     });
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -111,6 +111,15 @@
         {{/labs-ui/layer-group-toggle}}
       {{/lookup-layer-group}}
 
+      {{#lookup-layer-group for='boat-launches' as |layerGroup|}}
+        {{#labs-ui/layer-group-toggle
+          label=layerGroup.model.legend.label
+          active=layerGroup.model.visible
+          icon=layerGroup.model.legend.icon
+        }}
+        {{/labs-ui/layer-group-toggle}}
+      {{/lookup-layer-group}}
+
     {{/labs-ui/layer-groups-container}}
 
     {{#labs-ui/layer-groups-container title='Filter Spaces' open=false}}


### PR DESCRIPTION
- added boat launches layer group to labs-layers-api

-visualized similar to entry points (circle with smaller, lighter circle inside) but blue

- when a user hovers over the point, a tooltip shows the "name" of the boat launch and a message "(click for launch info)"

- when the user clicks on a point, they are redirected to that specific launch point's information page on Parks website through grabbing the "link" column in the carto layer. e.g. https://www.nycgovparks.org/facilities/kayak/32

- legend placement is right underneath entry points and the default is visible = true

- removed {{notes}} from tooltipTemplate on entry points (talked with Chris from waterfront about this)