### PR TITLE
add how-to-search text to about tab

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -9,6 +9,10 @@
 
   <p>Parks, esplanades, and other publicly-accessible spaces on the waterfront provide opportunities for relaxation, recreation, boating, and other activities that allow visitors and residents alike to experience New York City’s 520 miles of waterfront. Public and private investments&mdash;as well as effective waterfront zoning regulations&mdash;have expanded the variety of waterfront parks and open spaces available for public use.</p>
 
+  <h4>How to Search for a Waterfront Access Area</h4>
+
+  <p> Search for a builing address, waterfront name, waterfront location (cross streets), waterfront description, or adjacent body of water and easily locate addresses and waterfront access areas on the map.</p>
+
   <p><strong>{{link-to 'Learn more about waterfront zoning...' 'waterfront-zoning-for-public-access' class="button gray expanded"}}</strong></p>
 
   <p>The public sites are a combination of City, State, and Federal waterfront parklands and open spaces, as well as private sites that provide public access down to the shoreline. These privately-owned sites are known as Waterfront Public Access Areas (WPAAs). Each WPAA profile here provides information and photos on the history and available amenities at each site. For publicly accessible waterfront sites on public property, there is a link to the agency’s website under whose jurisdiction that property falls, providing additional information. The map will also help you find new waterfront spaces you may not know about and report any issues with these public spaces remaining accessible and well-maintained.</p>

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -9,10 +9,6 @@
 
   <p>Parks, esplanades, and other publicly-accessible spaces on the waterfront provide opportunities for relaxation, recreation, boating, and other activities that allow visitors and residents alike to experience New York City’s 520 miles of waterfront. Public and private investments&mdash;as well as effective waterfront zoning regulations&mdash;have expanded the variety of waterfront parks and open spaces available for public use.</p>
 
-  <h4>How to Search for a Waterfront Access Area</h4>
-
-  <p> Search for a building address, waterfront name, waterfront location (cross streets), waterfront description, or adjacent body of water and easily locate addresses and waterfront access areas on the map.</p>
-
   <p><strong>{{link-to 'Learn more about waterfront zoning...' 'waterfront-zoning-for-public-access' class="button gray expanded"}}</strong></p>
 
   <p>The public sites are a combination of City, State, and Federal waterfront parklands and open spaces, as well as private sites that provide public access down to the shoreline. These privately-owned sites are known as Waterfront Public Access Areas (WPAAs). Each WPAA profile here provides information and photos on the history and available amenities at each site. For publicly accessible waterfront sites on public property, there is a link to the agency’s website under whose jurisdiction that property falls, providing additional information. The map will also help you find new waterfront spaces you may not know about and report any issues with these public spaces remaining accessible and well-maintained.</p>

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -11,7 +11,7 @@
 
   <h4>How to Search for a Waterfront Access Area</h4>
 
-  <p> Search for a builing address, waterfront name, waterfront location (cross streets), waterfront description, or adjacent body of water and easily locate addresses and waterfront access areas on the map.</p>
+  <p> Search for a building address, waterfront name, waterfront location (cross streets), waterfront description, or adjacent body of water and easily locate addresses and waterfront access areas on the map.</p>
 
   <p><strong>{{link-to 'Learn more about waterfront zoning...' 'waterfront-zoning-for-public-access' class="button gray expanded"}}</strong></p>
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -17,7 +17,7 @@
 
 <div class="site-main grid-x has-content-open">
   {{#labs-search
-    searchPlaceholder='Search...'
+    searchPlaceholder='Enter location, name, or description...'
     onSelect=(action 'handleSearchSelect')
     searchTerms=searchTerms
     typeTitleLookup=(hash


### PR DESCRIPTION
"Search for a building address, waterfront name, waterfront location (cross streets), waterfront description, or adjacent body of water and easily locate addresses and waterfront access areas on the map."

So that users know all of the options that are available for them to search 
