### PR TITLE
add tooltip next to construction status

### DIFF
--- a/app/components/icon-tooltip.js
+++ b/app/components/icon-tooltip.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import { argument } from '@ember-decorators/argument';
+
+export default class InfoTooltip extends Component {
+  tagName = 'span'
+
+  @argument
+  tip = ''
+
+  @argument
+  icon = 'info-circle'
+}

--- a/app/templates/components/icon-tooltip.hbs
+++ b/app/templates/components/icon-tooltip.hbs
@@ -1,0 +1,7 @@
+{{#tool-tipster
+  content=tip
+  tagName="span"
+}}
+  {{~fa-icon icon~}}
+{{/tool-tipster}}
+{{yield}}

--- a/app/templates/profiles/show.hbs
+++ b/app/templates/profiles/show.hbs
@@ -46,6 +46,13 @@
             {{/if}}
           </span>
           {{model.construction_status}}
+          <sup>
+            {{icon-tooltip
+              tip='The construction status reflects the best available information at the time of website update. Please note that site status may have changed and sites may occasionally need to be temporarily partially or fully closed for maintenance or safety reasons.'
+              icon='exclamation-circle'
+              class="dark-gray"
+            }}
+          </sup>
           {{!-- {{model.status}} --}}
           {{!-- TODO: ^ These two are basically the same. Which should display? Are they chosen from a list or entered freeform? --}}
         </h5>

--- a/tests/integration/components/icon-tooltip-test.js
+++ b/tests/integration/components/icon-tooltip-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | icon-tooltip', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{icon-tooltip}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#icon-tooltip}}
+        template block text
+      {{/icon-tooltip}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
- add new component called "icon-tooltip"

- this component uses ember tooltipster

- "tip" and "icon" are arguments that we can then set in the template (we just do tip='text'). For the icon, the default is set to "info-circle", but I set it to exclamation-circle in the template. 

Closes #112