### PR TITLE
Add citibike stations

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -40,6 +40,13 @@ export default class ApplicationRoute extends Route {
             clickable: true,
           }],
         },
+        {
+          id: 'citibike-stations',
+          visible: false,
+          layers: [{
+            tooltipTemplate: '{{name}}<br> <strong><font color="blue" size=2>{{bikes_available}}</font></strong> available bikes<br> <strong><font color="blue" size=2>{{docks_available}}</font></strong> available docks',
+          }],
+        },
         { id: 'bike-routes', visible: false },
         { id: 'subway', visible: false },
         { id: 'aerials', visible: false },

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -191,6 +191,15 @@
         {{/labs-ui/layer-group-toggle}}
       {{/lookup-layer-group}}
 
+      {{#lookup-layer-group for='citibike-stations' as |layerGroup|}}
+        {{#labs-ui/layer-group-toggle
+          label=layerGroup.model.legend.label
+          active=layerGroup.model.visible
+          icon=layerGroup.model.legend.icon
+        }}
+        {{/labs-ui/layer-group-toggle}}
+      {{/lookup-layer-group}}
+
       {{#lookup-layer-group for='subway' as |layerGroup|}}
         {{#labs-ui/layer-group-toggle
           label=layerGroup.model.legend.label


### PR DESCRIPTION
-citibike stations as points. Layer-group pulls from a live feed from citibike. This data is stored on carto and is synced every hour

-removed all stations with capacity 0 as they either are not in service, are under construction, or don't exist

-tooltip displays how many available bikes and how many available docks 

-NOTE: right now I am displaying the dock/bike information as a hover tooltip but I'm thinking that there will be a lot of mobile users wanting this, so maybe a clickable popup will be better