### PR TITLE
104 improve mobile

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -16,6 +16,8 @@ export default class ApplicationController extends Controller {
 
   @alias('layerGroupService.visibleLayerGroups') visibleLayerGroups;
 
+  sidebarIsClosed = true;
+
   geocodedFeature = null;
 
   highlightedParkSource = null;

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import carto from 'cartobox-promises-utility/utils/carto';
+import { action } from '@ember-decorators/object'; // eslint-disable-line
 
 const query = `
   WITH
@@ -28,5 +29,11 @@ export default class ShowProjectRoute extends Route {
   async model() {
     const [data] = await carto.SQL(query);
     return data;
+  }
+
+  @action
+  didTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
   }
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -72,6 +72,9 @@ export default class ApplicationRoute extends Route {
 
   @action
   didTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
+
     next(function() {
       // not supported in IE 11
       window.dispatchEvent(new Event('resize'));

--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -1,8 +1,15 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember-decorators/object'; // eslint-disable-line
 
-export default Route.extend({
-  model() {
+export default class DataRoute extends Route {
+  async model() {
     const sources = this.store.peekAll('source');
     return sources.toArray().uniqBy('meta.description');
-  },
-});
+  }
+
+  @action
+  didTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
+  }
+}

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,6 +6,8 @@ export default class IndexRoute extends Route {
   @action
   didTransition() {
     const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
+
     next(() => {
       // not supported in IE 11
       window.dispatchEvent(new Event('resize'));

--- a/app/routes/profiles/show.js
+++ b/app/routes/profiles/show.js
@@ -30,6 +30,9 @@ export default class ShowProjectRoute extends Route {
 
   @action
   didTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
+
     const model = this.get('controller.model');
     next(() => {
       // not supported in IE 11

--- a/app/routes/waterfront-zoning-for-public-access.js
+++ b/app/routes/waterfront-zoning-for-public-access.js
@@ -1,4 +1,10 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember-decorators/object'; // eslint-disable-line
 
-export default Route.extend({
-});
+export default class WaterfrontZoningInfoRoute extends Route {
+  @action
+  didTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('sidebarIsClosed', true);
+  }
+}

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -83,6 +83,15 @@ $search-width: 17rem;
   }
 }
 
+.map-sidebar-toggle {
+  margin: rem-calc(10) rem-calc(10) rem-calc(12);
+  width: calc(100% - #{rem-calc(20)});
+
+  &.open {
+    margin-bottom: rem-calc(5);
+  }
+}
+
 .popup-content {
   width: 60vw;
   max-width: 14rem;
@@ -106,7 +115,7 @@ $search-width: 17rem;
   box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.1);
   background-color: $white;
   text-align: right;
-  padding: 1rem 1rem 0;
+  padding: 0 0.5rem 0.25rem;
   margin-bottom: -1rem;
 
   @include breakpoint(large) {
@@ -156,8 +165,8 @@ $search-width: 17rem;
 }
 
 // On medium screens, if the content area is not open, make the map and sidebar full-height.
-@include breakpoint(medium) {
-  .index-active-detector.active + .site-main {
+.index-active-detector.active + .site-main {
+  @include breakpoint(medium) {
     .map-container { height: calc(100vh - #{$site-header-height}); }
     .map-sidebar { height: calc(100vh - #{$site-header-height} - #{$search-height}); }
   }

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -47,7 +47,11 @@ $search-width: 17rem;
 }
 
 .map-container {
-  height: 60vh;
+  height: 50vh;
+
+  @include breakpoint(medium) {
+    height: 60vh;
+  }
 
   @include breakpoint(large) {
     height: 100%;
@@ -153,11 +157,9 @@ $search-width: 17rem;
 
 // On medium screens, if the content area is not open, make the map and sidebar full-height.
 @include breakpoint(medium) {
-  .site-main:not(.has-content-open) {
-    .map-container,
-    .sidebar {
-      height: calc(100vh - #{$site-header-height});
-    }
+  .index-active-detector.active + .site-main {
+    .map-container { height: calc(100vh - #{$site-header-height}); }
+    .map-sidebar { height: calc(100vh - #{$site-header-height} - #{$search-height}); }
   }
 }
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,8 +15,8 @@
   {{/banner.nav}}
 {{/labs-ui/site-header}}
 
-{{link-to '' 'index' class="index-active-detector"}}
-<div class="site-main grid-x has-content-open">
+{{link-to '' 'index' class="index-active-detector {{if sidebarIsClosed 'sidebar-is-closed' }}"}}
+<div class="site-main grid-x">
   {{#labs-search
     searchPlaceholder='Enter location, name, or description...'
     onSelect=(action 'handleSearchSelect')
@@ -98,118 +98,122 @@
   </div>
 
   <div class="map-sidebar cell large-order-1">
+    <button {{action (mut sidebarIsClosed) (not sidebarIsClosed)}} class="map-sidebar-toggle button tiny gray hide-for-medium {{unless sidebarIsClosed 'open'}}">
+      {{fa-icon (if sidebarIsClosed 'caret-down' 'caret-up')}}
+      Map Legend
+    </button>
+    <div class="{{if sidebarIsClosed 'show-for-medium'}}">
+      <section class="map-sidebar-section">
+        <h4 class="map-sidebar-title">Waterfront Public Access Areas</h4>
+        <p>The portion of privately owned waterfront zoning lots where publicly accessible open space is provided to and along the shoreline.</p>
 
-    <section class="map-sidebar-section">
-      <h4 class="map-sidebar-title">Waterfront Public Access Areas</h4>
-      <p>The portion of privately owned waterfront zoning lots where publicly accessible open space is provided to and along the shoreline.</p>
-
-      {{#lookup-layer-group for='waterfront-access--wpaas' as |layerGroup|}}
-        {{#each layerGroup.model.legend.items as |item|}}
-          {{labs-ui/legend-item item=item}}
-        {{/each}}
-      {{/lookup-layer-group}}
-
-      {{#lookup-layer-group for='waterfront-access--entry-points' as |layerGroup|}}
-        {{labs-ui/legend-item item=layerGroup.model.legend}}
-      {{/lookup-layer-group}}
-
-      <div class="amenity-filters-container">
-        <p style="margin:0.5rem 0 0.25rem;padding:0;"><strong>Filter WPAAs by site feature</strong></p>
-        {{#lookup-layer-group
-          for='waterfront-access--wpaas'
-          as |layerGroup|}}
-            {{#layer-group-filter
-              layerGroup=layerGroup.model
-              as |checkedValues updateValue|}}
-              {{#power-select-multiple
-                options=(site-feature-lookup)
-                selected=(filter-by (site-feature-lookup) checkedValues)
-                placeholder="Select features..."
-                searchField='label'
-                onchange=(action updateValue)
-                as |action|
-              }}
-                {{action.label}}
-              {{/power-select-multiple}}
-            {{/layer-group-filter}}
+        {{#lookup-layer-group for='waterfront-access--wpaas' as |layerGroup|}}
+          {{#each layerGroup.model.legend.items as |item|}}
+            {{labs-ui/legend-item item=item}}
+          {{/each}}
         {{/lookup-layer-group}}
-      </div>
-      <div class="amenity-filters-container">
-        <p style="margin:0.5rem 0 0.25rem;padding:0;"><strong>Filter WPAAs by active use amenity</strong></p>
-        {{#lookup-layer-group
-          for='waterfront-access--wpaas'
-          as |layerGroup|}}
-            {{#layer-group-filter
-              layerGroup=layerGroup.model
-              as |checkedValues updateValue|}}
-              {{#power-select-multiple
-                options=(activity-lookup)
-                selected=(filter-by (activity-lookup) checkedValues)
-                placeholder="Select activities..."
-                searchField='label'
-                onchange=(action updateValue)
-                as |action|
-              }}
-                {{action.label}}
-              {{/power-select-multiple}}
-            {{/layer-group-filter}}
+
+        {{#lookup-layer-group for='waterfront-access--entry-points' as |layerGroup|}}
+          {{labs-ui/legend-item item=layerGroup.model.legend}}
         {{/lookup-layer-group}}
-      </div>
-    </section>
 
-    <section class="map-sidebar-section">
-      {{#lookup-layer-group for='waterfront-access--publicly-owned' as |layerGroup|}}
-        {{labs-ui/legend-item item=layerGroup.model.legend class="bold-legend-item"}}
-      {{/lookup-layer-group}}
-      <p>City, State, and Federally owned parks and facilities that provide waterfront parkland and open space for public enjoyment.</p>
-    </section>
+        <div class="amenity-filters-container">
+          <p style="margin:0.5rem 0 0.25rem;padding:0;"><strong>Filter WPAAs by site feature</strong></p>
+          {{#lookup-layer-group
+            for='waterfront-access--wpaas'
+            as |layerGroup|}}
+              {{#layer-group-filter
+                layerGroup=layerGroup.model
+                as |checkedValues updateValue|}}
+                {{#power-select-multiple
+                  options=(site-feature-lookup)
+                  selected=(filter-by (site-feature-lookup) checkedValues)
+                  placeholder="Select features..."
+                  searchField='label'
+                  onchange=(action updateValue)
+                  as |action|
+                }}
+                  {{action.label}}
+                {{/power-select-multiple}}
+              {{/layer-group-filter}}
+          {{/lookup-layer-group}}
+        </div>
+        <div class="amenity-filters-container">
+          <p style="margin:0.5rem 0 0.25rem;padding:0;"><strong>Filter WPAAs by active use amenity</strong></p>
+          {{#lookup-layer-group
+            for='waterfront-access--wpaas'
+            as |layerGroup|}}
+              {{#layer-group-filter
+                layerGroup=layerGroup.model
+                as |checkedValues updateValue|}}
+                {{#power-select-multiple
+                  options=(activity-lookup)
+                  selected=(filter-by (activity-lookup) checkedValues)
+                  placeholder="Select activities..."
+                  searchField='label'
+                  onchange=(action updateValue)
+                  as |action|
+                }}
+                  {{action.label}}
+                {{/power-select-multiple}}
+              {{/layer-group-filter}}
+          {{/lookup-layer-group}}
+        </div>
+      </section>
 
-    <section class="map-sidebar-section">
-      {{#lookup-layer-group for='boat-launches' as |layerGroup|}}
-        {{#labs-ui/layer-group-toggle
-          label=layerGroup.model.legend.label
-          active=layerGroup.model.visible
-          icon=layerGroup.model.legend.icon
-        }}
-        {{/labs-ui/layer-group-toggle}}
-      {{/lookup-layer-group}}
+      <section class="map-sidebar-section">
+        {{#lookup-layer-group for='waterfront-access--publicly-owned' as |layerGroup|}}
+          {{labs-ui/legend-item item=layerGroup.model.legend class="bold-legend-item"}}
+        {{/lookup-layer-group}}
+        <p>City, State, and Federally owned parks and facilities that provide waterfront parkland and open space for public enjoyment.</p>
+      </section>
 
-      {{#lookup-layer-group for='ferries' as |layerGroup|}}
-        {{#labs-ui/layer-group-toggle
-          label=layerGroup.model.legend.label
-          active=layerGroup.model.visible
-          icon=layerGroup.model.legend.icon
-        }}
-        {{/labs-ui/layer-group-toggle}}
-      {{/lookup-layer-group}}
+      <section class="map-sidebar-section">
+        {{#lookup-layer-group for='boat-launches' as |layerGroup|}}
+          {{#labs-ui/layer-group-toggle
+            label=layerGroup.model.legend.label
+            active=layerGroup.model.visible
+            icon=layerGroup.model.legend.icon
+          }}
+          {{/labs-ui/layer-group-toggle}}
+        {{/lookup-layer-group}}
 
-      {{#lookup-layer-group for='bike-routes' as |layerGroup|}}
-        {{#labs-ui/layer-group-toggle
-          label=layerGroup.model.legend.label
-          active=layerGroup.model.visible
-          icon=layerGroup.model.legend.icon
-        }}
-        {{/labs-ui/layer-group-toggle}}
-      {{/lookup-layer-group}}
+        {{#lookup-layer-group for='ferries' as |layerGroup|}}
+          {{#labs-ui/layer-group-toggle
+            label=layerGroup.model.legend.label
+            active=layerGroup.model.visible
+            icon=layerGroup.model.legend.icon
+          }}
+          {{/labs-ui/layer-group-toggle}}
+        {{/lookup-layer-group}}
 
-      {{#lookup-layer-group for='subway' as |layerGroup|}}
-        {{#labs-ui/layer-group-toggle
-          label=layerGroup.model.legend.label
-          active=layerGroup.model.visible
-          icon=layerGroup.model.legend.icon
-        }}
-        {{/labs-ui/layer-group-toggle}}
-      {{/lookup-layer-group}}
+        {{#lookup-layer-group for='bike-routes' as |layerGroup|}}
+          {{#labs-ui/layer-group-toggle
+            label=layerGroup.model.legend.label
+            active=layerGroup.model.visible
+            icon=layerGroup.model.legend.icon
+          }}
+          {{/labs-ui/layer-group-toggle}}
+        {{/lookup-layer-group}}
 
-      {{#lookup-layer-group for='aerials' as |layerGroup|}}
-        {{#labs-ui/layer-group-toggle
-          label='2016 Aerials'
-          active=layerGroup.model.visible
-        }}
-        {{/labs-ui/layer-group-toggle}}
-      {{/lookup-layer-group}}
-    </section>
+        {{#lookup-layer-group for='subway' as |layerGroup|}}
+          {{#labs-ui/layer-group-toggle
+            label=layerGroup.model.legend.label
+            active=layerGroup.model.visible
+            icon=layerGroup.model.legend.icon
+          }}
+          {{/labs-ui/layer-group-toggle}}
+        {{/lookup-layer-group}}
 
+        {{#lookup-layer-group for='aerials' as |layerGroup|}}
+          {{#labs-ui/layer-group-toggle
+            label='2016 Aerials'
+            active=layerGroup.model.visible
+          }}
+          {{/labs-ui/layer-group-toggle}}
+        {{/lookup-layer-group}}
+      </section>
+    </div>
   </div>
 
   {{outlet}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,7 +4,7 @@
   as |banner|
 }}
   {{#banner.title}}
-    {{link-to 'Waterfront Access Map' 'index' class="site-title"}}
+    {{#link-to 'index' class="site-title"}}Waterfront Access <span class="show-for-medium">Map</span>{{/link-to}}
   {{/banner.title}}
   {{#banner.nav}}
     <ul class="menu vertical medium-horizontal">
@@ -15,6 +15,7 @@
   {{/banner.nav}}
 {{/labs-ui/site-header}}
 
+{{link-to '' 'index' class="index-active-detector"}}
 <div class="site-main grid-x has-content-open">
   {{#labs-search
     searchPlaceholder='Enter location, name, or description...'


### PR DESCRIPTION
This PR improves the UX on small screens by… 
- Making the map a bit shorter by default so that page/profile content below the fold is more noticeable 
- Prevents the site title from breaking the layout
- Uses a `link-to`'s active state to determine if we're on the index route so that the map and sidebar are full height on medium screens when there is no content 
- Adds a button to show/hide the legend on small screens — which required adding a `.set()` to every route (per @allthesignals, there's probably a better way to do this) 

Closes #104
