### PR TITLE
Single Resize Event

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,9 +1,22 @@
 import EmberRouter from '@ember/routing/router';
+import { next } from '@ember/runloop';
 import config from './config/environment';
 
 const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL,
+
+  didTransition(...args) {
+    this._super(...args);
+
+    next(function() {
+      // window.dispatchEvent(new Event('resize'));
+      // ^ not supported in IE 11, so we do this:
+      const resizeEvent = window.document.createEvent('UIEvents');
+      resizeEvent.initUIEvent('resize', true, false, window, 0);
+      window.dispatchEvent(resizeEvent);
+    });
+  },
 });
 
 Router.map(function() { // eslint-disable-line

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import carto from 'cartobox-promises-utility/utils/carto';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-import { next } from '@ember/runloop';
+// import { next } from '@ember/runloop';
 
 const query = `
   WITH
@@ -36,14 +36,5 @@ export default class ShowProjectRoute extends Route {
   didTransition() {
     const applicationController = this.controllerFor('application');
     applicationController.set('sidebarIsClosed', true);
-
-    next(function() {
-      // not supported in IE 11
-      // window.dispatchEvent(new Event('resize'));
-
-      const resizeEvent = window.document.createEvent('UIEvents');
-      resizeEvent.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(resizeEvent);
-    });
   }
 }

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import carto from 'cartobox-promises-utility/utils/carto';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-// import { next } from '@ember/runloop';
 
 const query = `
   WITH

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember-decorators/service';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-// import { next } from '@ember/runloop';
 import { hash } from 'rsvp';
 
 export default class ApplicationRoute extends Route {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember-decorators/service';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-import { next } from '@ember/runloop';
+// import { next } from '@ember/runloop';
 import { hash } from 'rsvp';
 
 export default class ApplicationRoute extends Route {
@@ -94,14 +94,5 @@ export default class ApplicationRoute extends Route {
   didTransition() {
     const applicationController = this.controllerFor('application');
     applicationController.set('sidebarIsClosed', true);
-
-    next(function() {
-      // not supported in IE 11
-      // window.dispatchEvent(new Event('resize'));
-
-      const resizeEvent = window.document.createEvent('UIEvents');
-      resizeEvent.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(resizeEvent);
-    });
   }
 }

--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-// import { next } from '@ember/runloop';
 
 export default class DataRoute extends Route {
   async model() {

--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-import { next } from '@ember/runloop';
+// import { next } from '@ember/runloop';
 
 export default class DataRoute extends Route {
   async model() {
@@ -12,14 +12,5 @@ export default class DataRoute extends Route {
   didTransition() {
     const applicationController = this.controllerFor('application');
     applicationController.set('sidebarIsClosed', true);
-
-    next(function() {
-      // not supported in IE 11
-      // window.dispatchEvent(new Event('resize'));
-
-      const resizeEvent = window.document.createEvent('UIEvents');
-      resizeEvent.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(resizeEvent);
-    });
   }
 }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-// import { next } from '@ember/runloop';
 
 export default class IndexRoute extends Route {
   @action

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,22 +1,11 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-import { next } from '@ember/runloop';
+// import { next } from '@ember/runloop';
 
 export default class IndexRoute extends Route {
   @action
   didTransition() {
     const applicationController = this.controllerFor('application');
     applicationController.set('sidebarIsClosed', true);
-
-    next(() => {
-      // not supported in IE 11
-      // window.dispatchEvent(new Event('resize'));
-
-      const resizeEvent = window.document.createEvent('UIEvents');
-      resizeEvent.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(resizeEvent);
-
-      applicationController.set('highlightedFeature', null);
-    });
   }
 }

--- a/app/routes/waterfront-zoning-for-public-access.js
+++ b/app/routes/waterfront-zoning-for-public-access.js
@@ -1,6 +1,5 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-// import { next } from '@ember/runloop';
 
 export default class WaterfrontZoningInfoRoute extends Route {
   @action

--- a/app/routes/waterfront-zoning-for-public-access.js
+++ b/app/routes/waterfront-zoning-for-public-access.js
@@ -1,20 +1,11 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember-decorators/object'; // eslint-disable-line
-import { next } from '@ember/runloop';
+// import { next } from '@ember/runloop';
 
 export default class WaterfrontZoningInfoRoute extends Route {
   @action
   didTransition() {
     const applicationController = this.controllerFor('application');
     applicationController.set('sidebarIsClosed', true);
-
-    next(function() {
-      // not supported in IE 11
-      // window.dispatchEvent(new Event('resize'));
-
-      const resizeEvent = window.document.createEvent('UIEvents');
-      resizeEvent.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(resizeEvent);
-    });
   }
 }


### PR DESCRIPTION
This PR removes the repeated `resizeEvent` code in every single route and adds it to an extended `didTransition()` in `router.js`. 

@allthesignals, we're still repeating this code in every route's `didTransition()`: 

```
const applicationController = this.controllerFor('application');
applicationController.set('sidebarIsClosed', true);
```

I wasn't able to simplify that too. Do you know if it's possible to access the application controller from within `router.js`? 

(Or maybe I'm doing this all wrong. Please review.)