### PR TITLE
update production search in environment.js

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -74,6 +74,8 @@ module.exports = function(environment) {
     ENV['mapbox-gl'].map.style = 'https://layers-api.planninglabs.nyc/v1/base/style.json';
     ENV['labs-search'] = {
       host: 'https://search-api.planninglabs.nyc',
+      route: 'search',
+      helpers: ['geosearch', 'waterfront-park-name'],
     };
     ENV['ember-mapbox-composer'] = {
       host: 'https://layers-api.planninglabs.nyc',


### PR DESCRIPTION
Small fix to make sure that search shows up for waterfront park names in Production mode by adding to Production environment in config/environment.js