### PR TITLE
Add simple Google Analytics

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,13 +1,17 @@
 import EmberRouter from '@ember/routing/router';
-import { next } from '@ember/runloop';
+import { next, scheduleOnce } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import config from './config/environment';
 
 const Router = EmberRouter.extend({
+  metrics: service(),
+
   location: config.locationType,
   rootURL: config.rootURL,
 
   didTransition(...args) {
     this._super(...args);
+    this._trackPage();
 
     next(function() {
       // window.dispatchEvent(new Event('resize'));
@@ -17,6 +21,15 @@ const Router = EmberRouter.extend({
       window.dispatchEvent(resizeEvent);
     });
   },
+
+  _trackPage() {
+    scheduleOnce('afterRender', this, () => {
+      const page = this.url;
+      const title = this.getWithDefault('currentRouteName', 'unknown');
+      this.metrics.trackPage({ page, title });
+    });
+  },
+
 });
 
 Router.map(function() { // eslint-disable-line

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,7 +48,7 @@ module.exports = function(environment) {
         name: 'GoogleAnalytics',
         environments: ['development', 'production'],
         config: {
-          id: 'UA-84250233-13',
+          id: 'UA-84250233-15',
           debug: environment === 'development',
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,6 +43,20 @@ module.exports = function(environment) {
       },
     },
 
+    metricsAdapters: [
+      {
+        name: 'GoogleAnalytics',
+        environments: ['development', 'production'],
+        config: {
+          id: 'UA-84250233-13',
+          debug: environment === 'development',
+          trace: environment === 'development',
+          // Ensure development env hits aren't sent to GA
+          sendHitTask: (environment !== 'development' && environment !== 'devlocal'),
+        },
+      },
+    ],
+
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-load-initializers": "^1.1.0",
     "ember-mapbox-composer": "^0.0.18",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-metrics": "^0.12.1",
     "ember-moment": "^7.8.0",
     "ember-parachute": "0.3.7",
     "ember-power-select": "2.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3243,7 +3243,7 @@ ember-cli-babel-plugin-helpers@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.17.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
   dependencies:
@@ -3788,7 +3788,7 @@ ember-get-config@^0.2.3, ember-get-config@^0.2.4:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
 
-ember-getowner-polyfill@^2.0.1:
+ember-getowner-polyfill@^2.0.0, ember-getowner-polyfill@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
   dependencies:
@@ -3860,6 +3860,15 @@ ember-maybe-in-element@^0.1.3:
   resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
   dependencies:
     ember-cli-babel "^6.11.0"
+
+ember-metrics@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.12.1.tgz#8659343bf7b8bda403e70d482ff59cc9714d89f6"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    ember-cli-babel "^6.1.0"
+    ember-getowner-polyfill "^2.0.0"
+    ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
 ember-moment@^7.8.0:
   version "7.8.0"
@@ -3938,6 +3947,13 @@ ember-router-generator@^1.2.3:
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
   dependencies:
     recast "^0.11.3"
+
+ember-runtime-enumerable-includes-polyfill@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.1.0.tgz#dc6d4a028471e4acc350dfd2a149874fb20913f5"
+  dependencies:
+    ember-cli-babel "^6.9.0"
+    ember-cli-version-checker "^2.1.0"
 
 ember-source-channel-url@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
I added simple Google Analytics to track **page** visits to the site. 

If we feel it is important to track **events** as well I can definitely add Analytics for that, too.
(Examples of Events --> clicking on Site Feature drop-down, toggling layers, inputting and clicking on search results, etc.)

