### PR TITLE
use-aliased-data

### DIFF
--- a/app/adapters/profile.js
+++ b/app/adapters/profile.js
@@ -38,7 +38,7 @@ const SQL = function(id) {
       activity_splash_feature,
       activity_other_recreational_facilities,
       activity_swimming
-    FROM wpaas_v201811
+    FROM wpaas
     WHERE paws_id='${id}'
   `;
 };

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -7,14 +7,14 @@ const query = `
   publiclyowned AS (
     SELECT
       count(*)
-    FROM planninglabs.publiclyownedwaterfront_v201810
+    FROM planninglabs.publiclyownedwaterfront
     WHERE status LIKE 'Constructed%25'
   ),
 
   paws AS (
     SELECT
       count(*)
-    FROM wpaas_v201811
+    FROM wpaas
     WHERE constructi LIKE '%25Open'
   )
 


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to https://github.com/NYCPlanning/labs-layers-api/pull/124