### PR TITLE
175: refactor tooltip-renderer component to fix hover tooltip bug

### DIFF
--- a/app/components/tooltip-renderer.js
+++ b/app/components/tooltip-renderer.js
@@ -1,25 +1,20 @@
 import Component from '@ember/component';
 import { argument } from '@ember-decorators/argument';
-import { defineProperty, computed as computedProperty } from '@ember/object';
-import Ember from 'ember';
+import { computed } from '@ember-decorators/object';
+import mustache from 'mustache';
 
 export default class TooltipRenderer extends Component {
-  init(...args) {
-    super.init(...args);
-
-    this.setProperties(this.get('feature.properties'));
-
-    defineProperty(this, 'layout', computedProperty(() => {
-      const template = this.get('template');
-      const { properties } = this.get('feature');
-
-      return Ember.HTMLBars.compile(template, properties);
-    }));
-  }
-
   @argument
   feature = {}
 
   @argument
   template = ''
+
+  @computed('feature', 'template')
+  get renderedText() {
+    const properties = this.get('feature.properties');
+    const template = this.get('template');
+
+    return mustache.render(template, properties);
+  }
 }

--- a/app/templates/components/tooltip-renderer.hbs
+++ b/app/templates/components/tooltip-renderer.hbs
@@ -1,1 +1,3 @@
-{{{renderedText}}}
+{{#if template}}
+  {{renderedText}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-ember-best-practices": "^1.1.1",
     "eslint-plugin-import": "^2.14.0",
+    "mustache": "^4.0.0",
     "xml-js": "^1.6.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7663,6 +7663,11 @@ mustache@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-3.0.1.tgz#873855f23aa8a95b150fb96d9836edbc5a1d248a"
 
+mustache@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.0.tgz#7f02465dbb5b435859d154831c032acdfbbefb31"
+  integrity sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA==
+
 mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"


### PR DESCRIPTION
Preivously, no information was showing up when users would hover over the park polygons. This PR updates the tooltip-renderer component to mirror more closely that of our other apps (e.g. zola). This required installing mustache. We now use `mustache.render(template, properties)` instead of `Ember.HTMLBars.compile(template, properties)`.

Addresses #175 