### PR TITLE
177: update layer click action to reflect new data updates

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -30,13 +30,9 @@ export default class ApplicationController extends Controller {
 
   popupLocation = null;
 
-  popupWfParkId = null;
-
   popupParkName = null;
 
   popupAgency = null;
-
-  popupStatus = null;
 
   popupLink = null;
 
@@ -172,10 +168,10 @@ export default class ApplicationController extends Controller {
     this.set('popupFeature', false);
 
     if (feature) {
-      const { paws_id } = feature.properties;
+      const { wpaa_id } = feature.properties;
 
-      if (paws_id) {
-        this.transitionToRoute('profiles.show', paws_id);
+      if (wpaa_id) {
+        this.transitionToRoute('profiles.show', wpaa_id);
       } else {
         this.transitionToRoute('index');
       }
@@ -185,17 +181,15 @@ export default class ApplicationController extends Controller {
         next(() => {
           const {
             properties: {
-              wf_park_id: popupWfParkId,
               park_name: popupParkName,
               agency: popupAgency,
-              status: popupStatus,
               link: popupLink,
             },
           } = feature;
 
           this.set('popupFeature', true);
           this.setProperties({
-            popupWfParkId, popupParkName, popupAgency, popupStatus, popupLink,
+            popupParkName, popupAgency, popupLink,
           });
         });
       }


### PR DESCRIPTION
In `controllers/application.js`, where we handle map clicks in the action `handleLayerClick`, there were some outdated data references, so this PR:
- Replaces old id name (paws_id) for private parks layer with new updated id name (wpaa_id). This discrepancy is what was causing the bug where clicking on a private park polygon would not show the profile.
- Removes two column references that no longer exist for public parks --> `wf_park_id` and `status`

**WARNING before we merge**: Merging this into develop is fine because the staging version of `labs-layers-api` has the appropriate data updates. But before this is merged to master we MUST also promote the staging version of `labs-layers-api` to master as well. 

Addresses #177 