### PR TITLE
183 update about hyperlinks

### DIFF
--- a/app/controllers/about.js
+++ b/app/controllers/about.js
@@ -1,0 +1,16 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default Controller.extend({
+  application: controller('application'),
+
+  // for recent projects that don't have a carto row manually fly the user to the map
+  actions: {
+    flyTo(zoom, lat, lng) {
+      // global map object, set in applicationController
+      this.application.mapInstance.flyTo({
+        zoom,
+        center: { lng, lat },
+      });
+    },
+  },
+});

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -25,7 +25,7 @@ const query = `
   FROM publiclyowned, paws
 `;
 
-export default class ShowProjectRoute extends Route {
+export default class AboutRoute extends Route {
   async model() {
     const [data] = await carto.SQL(query);
     return data;

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -11,9 +11,9 @@
   <h4>Recent Map Updates:</h4>
   <div class="grid-x grid-margin-x">
     <p class="cell medium-6">
-      <a href="https://www.nycgovparks.org/parks/richmond-terrace-wetlands" target="_blank">
+      <a {{ action 'flyTo' 17.69 40.63734 -74.153696}}>
         <div style="background-image: url('{{rootURL}}images/RichmondTerracePark_DPR.jpg'); padding-top: 60%; background-size: cover;">
-          <strong style="color:White; background-color: rgba(0,0,0,0.4); display: block; padding: 1rem;">Richmond Terrace Park {{fa-icon 'external-link-alt'}}</strong>
+          <strong style="color:White; background-color: rgba(0,0,0,0.4); display: block; padding: 1rem;">Richmond Terrace Park</strong>
         </div>
       </a>
     </p>
@@ -37,9 +37,9 @@
     </p>
 
     <p class="cell medium-6">
-      <a href="https://parks.ny.gov/parks/200/details.aspx" target="_blank">
+      <a {{ action 'flyTo' 14.64 40.64683 -73.86632 }}>
         <div style="background-image: url('{{rootURL}}images/Shirley_Chisholm_state_park.jpg'); padding-top: 60%; background-size: cover;">
-          <strong style="color:White; background-color: rgba(0,0,0,0.4); display: block; padding: 1rem;">Shirley Chisholm State Park {{fa-icon 'external-link-alt'}}</strong>
+          <strong style="color:White; background-color: rgba(0,0,0,0.4); display: block; padding: 1rem;">Shirley Chisholm State Park</strong>
         </div>
       </a>
     </p>

--- a/tests/unit/controllers/about-test.js
+++ b/tests/unit/controllers/about-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | about', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const controller = this.owner.lookup('controller:about');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds an action to the About page & template, so when we have external projects (that we don't have a profile page for on click), we zoom the user to the map, where they can click on the map to go to the external documentation, if they chose.

Previously we were immediately bringing them to an external link, which was a jarring UX.

Closes #183 

![2020-02-20 16 49 06](https://user-images.githubusercontent.com/5316367/74981845-fc6daa00-5400-11ea-9b24-a7bfa9ba99c3.gif)
