### PR TITLE
Setting node version in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,7 @@
 [build]
 command = "yarn build --environment=staging"
+environment = { NODE_VERSION = "8.11.3" }
 
 [context.master]
 command = "yarn build --environment=production"
+environment = { NODE_VERSION = "8.11.3" }


### PR DESCRIPTION
This PR updates netlify.toml to set node version explicitly

Closes [AB#4916](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/4916)
