### PR TITLE
Upgrade labs-ui and remove beta banner

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,7 @@
 {{#labs-ui/site-header
   responsiveNav=true
   responsiveSize='medium'
+  betaNotice=false
   as |banner|
 }}
   {{#banner.title}}

--- a/package.json
+++ b/package.json
@@ -64,15 +64,15 @@
     "ember-source": "~3.5.0",
     "ember-welcome-page": "^3.2.0",
     "foundation-sites": "^6.4.3",
+    "husky": "^6.0.0",
     "labs-ember-cli-slick": "2.0.1",
     "labs-ember-search": "^2.4.9",
-    "labs-ui": "^0.0.11",
+    "labs-ui": "0.0.27",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.8.0",
-    "husky": "^6.0.0"
+    "qunit-dom": "^0.8.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.*"
   },
   "dependencies": {
     "@turf/bbox": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,28 +627,28 @@
     ember-cli-babel-plugin-helpers "^1.0.0"
     ember-cli-version-checker "^2.1.0"
 
-"@ember-decorators/component@^2.1.0", "@ember-decorators/component@^2.3.0", "@ember-decorators/component@^2.3.1", "@ember-decorators/component@^2.5.2":
+"@ember-decorators/component@^2.1.0", "@ember-decorators/component@^2.3.0", "@ember-decorators/component@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-2.5.2.tgz#54ceb0edbf8cc089b25174897639c5704532274f"
   dependencies:
     "@ember-decorators/utils" "^2.5.2"
     ember-cli-babel "^6.6.0"
 
-"@ember-decorators/controller@^2.1.0", "@ember-decorators/controller@^2.3.0", "@ember-decorators/controller@^2.3.1", "@ember-decorators/controller@^2.5.2":
+"@ember-decorators/controller@^2.1.0", "@ember-decorators/controller@^2.3.0", "@ember-decorators/controller@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/controller/-/controller-2.5.2.tgz#f74a537ba79d966b5bb1402f6407692c849ef9db"
   dependencies:
     "@ember-decorators/utils" "^2.5.2"
     ember-cli-babel "^6.6.0"
 
-"@ember-decorators/data@^2.1.0", "@ember-decorators/data@^2.3.0", "@ember-decorators/data@^2.3.1", "@ember-decorators/data@^2.5.2":
+"@ember-decorators/data@^2.1.0", "@ember-decorators/data@^2.3.0", "@ember-decorators/data@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/data/-/data-2.5.2.tgz#11411ccf2b94437ab3a6a23077cd39bd990ab334"
   dependencies:
     "@ember-decorators/utils" "^2.5.2"
     ember-cli-babel "^6.6.0"
 
-"@ember-decorators/object@^2.1.0", "@ember-decorators/object@^2.3.0", "@ember-decorators/object@^2.3.1", "@ember-decorators/object@^2.5.2":
+"@ember-decorators/object@^2.1.0", "@ember-decorators/object@^2.3.0", "@ember-decorators/object@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-2.5.2.tgz#3f0d238212da13bda94a129964b47387ed90054c"
   dependencies:
@@ -656,7 +656,7 @@
     ember-cli-babel "^6.6.0"
     ember-compatibility-helpers "^1.0.0"
 
-"@ember-decorators/service@^2.1.0", "@ember-decorators/service@^2.3.0", "@ember-decorators/service@^2.3.1", "@ember-decorators/service@^2.5.2":
+"@ember-decorators/service@^2.1.0", "@ember-decorators/service@^2.3.0", "@ember-decorators/service@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@ember-decorators/service/-/service-2.5.2.tgz#0ec93ca10f5e8baa8d93364c794de23a526e8493"
   dependencies:
@@ -709,6 +709,25 @@
     ember-cli-babel "^6.12.0"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
 
+"@fortawesome/ember-fontawesome@0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@fortawesome/ember-fontawesome/-/ember-fontawesome-0.1.8.tgz#79cc2fc9d1e0d67181227d12cd78fb27def95b79"
+  integrity sha512-82SVD+c8dVidJAaZGBXBCjEykksF67K6TxtaDTBNI3SljoXr9AwIIQPdw+PolACp0ATojPKcLxQ4uut4tWtWzQ==
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^1.2.0"
+    broccoli-file-creator "^1.1.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-plugin "^1.3.0"
+    broccoli-rollup "^2.0.0"
+    broccoli-source "^1.1.0"
+    camel-case "^3.0.0"
+    ember-ast-helpers "0.3.5"
+    ember-cli-babel "^6.6.0"
+    ember-cli-htmlbars "^2.0.3"
+    ember-get-config "^0.2.4"
+    glob "^7.1.2"
+    rollup-plugin-node-resolve "^3.0.2"
+
 "@fortawesome/ember-fontawesome@^0.1.5":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@fortawesome/ember-fontawesome/-/ember-fontawesome-0.1.9.tgz#57c5647d59bcfa4516cf35952daf8f9b4e4b5c37"
@@ -731,25 +750,45 @@
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.12.tgz#42baa71f97ca06faeb0b6718fa5ed20c5eefdf07"
 
+"@fortawesome/fontawesome-common-types@^0.2.6":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
 "@fortawesome/fontawesome-svg-core@^1.2.0":
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.12.tgz#9732617b1e484435f6946645d7f9ad248f12c437"
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.12"
 
-"@fortawesome/free-brands-svg-icons@^5.2.0":
-  version "5.6.3"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.6.3.tgz#f4ac2abab83822b341b3b7257c38b9da12ca7395"
+"@fortawesome/free-brands-svg-icons@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.4.1.tgz#7c68f7baff4764a8e38e62892372c4b85c70db79"
+  integrity sha512-kt81EOduizFQ8YHURrN1vl230Z8eOu05QysTtZejyJBrMrU1YSDUMNwlP5t8vYZ8VErWx5C1Kqom5OEctDKmrA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.12"
+    "@fortawesome/fontawesome-common-types" "^0.2.6"
 
-"@fortawesome/free-regular-svg-icons@^5.1.0", "@fortawesome/free-regular-svg-icons@^5.3.1":
+"@fortawesome/free-regular-svg-icons@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.4.1.tgz#50dcda7e0382af9ae2508b2322e6f82d2a9fd43a"
+  integrity sha512-qRSt/qqrACktOzozps1tSjpsu8KA22Bl0SP4v2sQRWScKVdC9UemELqWUKN/TXuKwQzXbveN0peiwrwUdYZlOw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.6"
+
+"@fortawesome/free-regular-svg-icons@^5.3.1":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.6.3.tgz#b0a44d665c347b56d064a37962e81e8d8a8f2624"
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.12"
 
-"@fortawesome/free-solid-svg-icons@^5.1.0", "@fortawesome/free-solid-svg-icons@^5.3.1":
+"@fortawesome/free-solid-svg-icons@5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.4.1.tgz#9aa1a07176a16886aa176fc0c9d809ab1697fd47"
+  integrity sha512-GRYr+T0sAnfjImhDJt6Gko3sW554+/fEUHgDFJonEEFYLbfLyv6Qn5i/VB8nXcJJLgqHbVwIvwH5Ol3IehIjow==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.6"
+
+"@fortawesome/free-solid-svg-icons@^5.3.1":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.6.3.tgz#1d7f6669ccd6a1ea673699e41f7e32c81401a260"
   dependencies:
@@ -2350,7 +2389,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -3908,17 +3947,6 @@ ember-cli-netlify@^0.1.0:
   dependencies:
     fs-extra "^5.0.0"
 
-ember-cli-node-assets@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-source "^1.1.0"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
-
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz#0b14f7bcbc599aa117b5fddc81e4fd03c4bad5b7"
@@ -4014,6 +4042,15 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
   dependencies:
     resolve "^1.3.3"
     semver "^5.3.0"
+
+ember-cli-what-input@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-what-input/-/ember-cli-what-input-1.0.0.tgz#6c43bf6aaed5a566c3f29f8d3a1760f724e5e924"
+  integrity sha512-jd9X/yAuv7EtBYLgvUMsLjKk9zz1sF/KFElr171rRQI2brqMopZHIa4eNCaXJpxaqDs5bGCflkc+zFzEiE5IUA==
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    what-input "^5.0.2"
 
 ember-cli@~3.5.0:
   version "3.5.1"
@@ -4205,18 +4242,6 @@ ember-decorators@2.3.0:
     "@ember-decorators/data" "^2.3.0"
     "@ember-decorators/object" "^2.3.0"
     "@ember-decorators/service" "^2.3.0"
-    ember-cli-babel "^6.0.0"
-    semver "^5.5.0"
-
-ember-decorators@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-2.3.1.tgz#aef98f6a3e15666bd414576d07cbfc15d39cfe97"
-  dependencies:
-    "@ember-decorators/component" "^2.3.1"
-    "@ember-decorators/controller" "^2.3.1"
-    "@ember-decorators/data" "^2.3.1"
-    "@ember-decorators/object" "^2.3.1"
-    "@ember-decorators/service" "^2.3.1"
     ember-cli-babel "^6.0.0"
     semver "^5.5.0"
 
@@ -4496,15 +4521,16 @@ ember-text-measurer@^0.4.0:
   dependencies:
     ember-cli-babel "^6.8.2"
 
-ember-tooltips@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ember-tooltips/-/ember-tooltips-3.0.0.tgz#bf864a81fc379dc3992fa6d4453cacfb14ffbacf"
+ember-tooltips@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ember-tooltips/-/ember-tooltips-3.1.0.tgz#99c6b9d96eaf907a6f7a2285a7a43239ae62698d"
+  integrity sha512-5GNsi+Lwr/svVm9WsO4DNNxtdsRIKY7M5eyuyKIG0CDd0ZZUScuTKRZmtx+XozDrJN6TYj/12jFAG8EZ9Myq8w==
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.6.0"
-    ember-cli-htmlbars "^2.0.1"
-    ember-cli-node-assets "^0.2.2"
+    ember-cli-babel "^6.16.0"
+    ember-cli-htmlbars "^3.0.0"
+    ember-get-config "^0.2.4"
     ember-wormhole "^0.5.5"
     popper.js "^1.12.5"
     tooltip.js "^1.1.5"
@@ -5515,6 +5541,14 @@ formatio@1.1.1:
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+
+foundation-sites@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/foundation-sites/-/foundation-sites-6.3.1.tgz#23853372deb9480c13b426499eaf0c8f90cdbe1d"
+  integrity sha512-APkuZfZOAWZWfzogXldrf4Oiy/nTZ7BtONbACK68/qUyFhLOKYikFs5Tm3Tfuyy9O3izjknBZHJstwfX0V+Qxw==
+  dependencies:
+    jquery ">=2.2.0"
+    what-input "^4.0.3"
 
 foundation-sites@^6.3.1, foundation-sites@^6.4.3:
   version "6.5.2"
@@ -6551,6 +6585,11 @@ jquery-deferred@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
 
+jquery@>=2.2.0:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.3.tgz#23ed2ffed8a19e048814f13391a19afcdba160e6"
+  integrity sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==
+
 jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -6749,24 +6788,23 @@ labs-ember-search@^2.4.9:
     ember-promise-helpers "1.0.6"
     ember-truth-helpers "2.0.0"
 
-labs-ui@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/labs-ui/-/labs-ui-0.0.11.tgz#702703e6fef86d31c531df3b5b6f7e4745959316"
+labs-ui@0.0.27:
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/labs-ui/-/labs-ui-0.0.27.tgz#24928814d178c3dc07d552db2335eabc06c09478"
+  integrity sha512-LtsExMDSXeOMLX53el/PXpV1S6e8f6QW9kACTISwOjF2PrNXOa0yoKNJymyc9J8uBUh0s81Pp67NhfxHz0qjOg==
   dependencies:
-    "@ember-decorators/argument" "0.8.15"
-    "@ember-decorators/babel-transforms" "^2.0.0"
-    "@fortawesome/ember-fontawesome" "^0.1.5"
-    "@fortawesome/free-brands-svg-icons" "^5.2.0"
-    "@fortawesome/free-regular-svg-icons" "^5.1.0"
-    "@fortawesome/free-solid-svg-icons" "^5.1.0"
+    "@fortawesome/ember-fontawesome" "0.1.8"
+    "@fortawesome/free-brands-svg-icons" "5.4.1"
+    "@fortawesome/free-regular-svg-icons" "5.4.1"
+    "@fortawesome/free-solid-svg-icons" "5.4.1"
     ember-cli-babel "^6.17.0"
     ember-cli-foundation-6-sass "^0.0.25"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
     ember-cli-sass "^6.2.0"
-    ember-decorators "2.3.1"
-    ember-tooltips "3.0.0"
-    foundation-sites "^6.3.1"
+    ember-cli-what-input "^1.0.0"
+    ember-tooltips "3.1.0"
+    foundation-sites "6.3.1"
     mapbox-gl "^0.48.0"
 
 lcid@^1.0.0:
@@ -7192,7 +7230,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -8963,7 +9001,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1, resolve@^1.9.0:
+resolve@^1.1.5, resolve@^1.1.6, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.7.1, resolve@^1.8.1, resolve@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.0.tgz#3bdaaeaf45cc07f375656dfd2e54ed0810b101ba"
   dependencies:
@@ -10478,6 +10516,16 @@ websocket-extensions@>=0.1.1:
 wgs84@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
+
+what-input@^4.0.3:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/what-input/-/what-input-4.3.1.tgz#b8ea7554ba1d9171887c4c6addf28185fec3d31d"
+  integrity sha512-7KD71RWNRWI9M08shZ8+n/2UjO5amwsG9PMSXWz0iIlH8H2DVbHE8Z2tW1RqQa0kIwdeqdUIffFz7crDfkcbAw==
+
+what-input@^5.0.2:
+  version "5.2.12"
+  resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.12.tgz#6eb5b5d39ebff4e2273df8bf69d8d2fc9a6e060a"
+  integrity sha512-3yrSa7nGSXGJS6wZeSkO6VNm95pB1mZ9i3wFzC1hhY7mn4/afue/MvXz04OXNdBC8bfo4AB4RRd3Dem9jXM58Q==
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR upgrades `labs-ui` to a version that has the `betaNotice` prop on the SiteHeader component and uses that to hide the "beta project" banner

