### PR TITLE
Task 13290: set popupFeature state to false on popup close

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -164,9 +164,12 @@ export default class ApplicationController extends Controller {
   }
 
   @action
-  handleLayerClick(feature) {
+  popupClosed() {
     this.set('popupFeature', false);
+  }
 
+  @action
+  handleLayerClick(feature) {
     if (feature) {
       const { wpaa_id } = feature.properties;
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -81,7 +81,7 @@
       {{map.on 'click' (action 'mapClicked')}}
 
       {{#if popupFeature}}
-        {{#map.popup lngLat=popupLocation}}
+        {{#map.popup lngLat=popupLocation onClose=(action 'popupClosed')}}
           <div class="popup-content">
             {{#if popupParkName}}
               <h3 class="header-medium small-margin-bottom">{{popupParkName}}</h3>


### PR DESCRIPTION
## Analysis
Mapbox was closing the popup when clicking on the map as part of its native default behavior. However, the application popup state remained 'true' and waiting for another click to reopen it.

Having the popup state being reset to 'false' on layer click was ineffective for scenarios where the popup was closed by clicking somewhere besides a layer.

## Remedy
Mapbox popup classes natively support an 'onClose' method. This code change moves the 'popup state reset' to a function that will fire when mapbox closes the popup. This should bring the mapbox and application state into unison with each other.

Closes Bug [AB#13195](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13195), Task [AB#13290](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13290)
