### PR TITLE
Clear highlight when transitioning away from park

### DIFF
--- a/app/routes/profiles/show.js
+++ b/app/routes/profiles/show.js
@@ -47,4 +47,10 @@ export default class ShowProjectRoute extends Route {
       this.get('fitBoundsWhenReady').perform(model.get('geometry'));
     });
   }
+
+  @action
+  willTransition() {
+    const applicationController = this.controllerFor('application');
+    applicationController.set('highlightedFeature', null);
+  }
 }


### PR DESCRIPTION
# Description
The highlight remained on a park, even after navigating away

# Change
On `willTransition` action within waterfront router, clear the highlighted feature

Bug AB#13199
Task AB#13292
