### PR TITLE
Change reference to paws_id column to wpaa_id

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -148,7 +148,7 @@ export default class ApplicationController extends Controller {
 
     // handle park name search results
     if (result.type === 'waterfront-park-name') {
-      this.transitionToRoute('profiles.show', result.paws_id);
+      this.transitionToRoute('profiles.show', result.wpaa_id);
     }
   }
 


### PR DESCRIPTION
This PR changes a reference to `paws_id` to `wpaa_id` to match with the underlying table schema in the data coming back from Search API.