### PR TITLE
Use staging layers api in develop context

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const LABS_SEARCH_HOST = process.env.LABS_SEARCH_HOST || 'https://search-api-production.herokuapp.com';
+const HOST = process.env.API_HOST || 'https://layers-api.planninglabs.nyc';
 
 module.exports = function (environment) {
   const ENV = {
@@ -8,7 +9,7 @@ module.exports = function (environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
-    host: 'https://layers-api-staging.planninglabs.nyc',
+    host: HOST,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
@@ -27,14 +28,14 @@ module.exports = function (environment) {
     },
 
     'ember-mapbox-composer': {
-      host: 'https://layers-api-staging.planninglabs.nyc',
+      host: HOST,
       namespace: 'v1',
     },
 
     'mapbox-gl': {
       accessToken: '',
       map: {
-        style: 'https://layers-api-staging.planninglabs.nyc/v1/base/style.json',
+        style: `${HOST}/v1/base/style.json`,
       },
     },
 
@@ -54,7 +55,8 @@ module.exports = function (environment) {
           debug: environment === 'development',
           trace: environment === 'development',
           // Ensure development env hits aren't sent to GA
-          sendHitTask: (environment !== 'development' && environment !== 'devlocal'),
+          sendHitTask:
+            environment !== 'development' && environment !== 'devlocal',
         },
       },
       {
@@ -93,14 +95,6 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
-  }
-
-  if (environment === 'production') {
-    ENV.host = 'https://layers-api.planninglabs.nyc';
-    ENV['mapbox-gl'].map.style = 'https://layers-api.planninglabs.nyc/v1/base/style.json';
-    ENV['ember-mapbox-composer'] = {
-      host: 'https://layers-api.planninglabs.nyc',
-    };
   }
 
   if (environment === 'devlocal') {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 command = "yarn build"
 
 [context.develop]
-command = "LABS_SEARCH_HOST=https://search-api-staging.herokuapp.com yarn build"
+command = "API_HOST=https://layers-api-staging.planninglabs.nyc LABS_SEARCH_HOST=https://search-api-staging.herokuapp.com yarn build"


### PR DESCRIPTION
This PR updates `netlify.toml` and `environment.js` such that the app gets the URL for Layers API from an env var, if it is present. This is based on the approach taken in [Zola](https://github.com/NYCPlanning/labs-zola/blob/develop/config/environment.js#L3). The env var is set to the staging Layers API URL in netlify.toml for deploys done under the develop context, meaning deployments of the develop branch, hosted at https://waterfront-access-staging.planninglabs.nyc/, should point to the staging layers API url. This will be used for upcoming updates to some of the waterfront datasets, allowing us to test the new data in the staging environment.